### PR TITLE
GitHub's git password authentication is shutting down

### DIFF
--- a/en-gb/guide.md
+++ b/en-gb/guide.md
@@ -30,10 +30,6 @@ Don't forget to check if FastGit is down when you are troubleshooting network er
 :::
 
 :::warning Note
-You will fail to push or to do other operations which need your authorisation after you turn FA2 on unless using [access token](https://github.com/settings/tokens) as your password.
-:::
-
-:::warning Note
 We do NOT support that clone repositories which are over 2GiB. Read more <https://github.com/FastGitORG/nginx-conf/issues/14> and <https://github.com/FastGitORG/nginx-conf/commit/61a41bc0bbb012fc9a6e54b198a10874eeaf9309>.
 :::
 

--- a/it-it/guide.md
+++ b/it-it/guide.md
@@ -30,10 +30,6 @@ Non dimentichi di controllare se FastGit è giù quando risolve errori di rete, 
 :::
 
 :::warning Nota
-Non riuscirete a spingere o a fare altre operazioni che richiedono la vostra autorizzazione dopo aver acceso FA2, a meno che non usiate il [token di accesso](https://github.com/settings/tokens) come password.
-:::
-
-:::warning Nota
 NON supportiamo i repository clonati che superano i 2GiB. Leggi di più <https://github.com/FastGitORG/nginx-conf/issues/14> e <https://github.com/FastGitORG/nginx-conf/commit/61a41bc0bbb012fc9a6e54b198a10874eeaf9309>.
 :::
 

--- a/zh-cn/guide.md
+++ b/zh-cn/guide.md
@@ -28,10 +28,6 @@ git config protocol.https.allow always
 :::
 
 :::warning 注意
-当开启 2FA 功能后， push 等需要您身份验证的操作会被拒绝，除非您使用[连接令牌](https://github.com/settings/tokens)。
-:::
-
-:::warning 注意
 我们暂时不支持超过 2GiB 的仓库的 `clone`，请参阅 <https://github.com/FastGitORG/nginx-conf/issues/14> 与 <https://github.com/FastGitORG/nginx-conf/commit/61a41bc0bbb012fc9a6e54b198a10874eeaf9309>。
 :::
 

--- a/zh-tw/guide.md
+++ b/zh-tw/guide.md
@@ -28,11 +28,6 @@ git config protocol.https.allow always
 :::
 
 :::warning 注意
-當開啟 2FA 功能後， push 等需要您身份驗證的操作會被拒絕，除非您使用[連接令牌](https://github.com/settings/tokens)。
-:::
-
-
-:::warning 注意
 我們暫時不支持超過 2GiB 的倉庫的 `clone`，請參閱 <https://github.com/FastGitORG/nginx-conf/issues/14> 与 <https://github.com/FastGitORG/nginx-conf/commit/61a41bc0bbb012fc9a6e54b198a10874eeaf9309>>。
 :::
 


### PR DESCRIPTION
- [Git password authentication is shutting down - The GitHub Blog](https://github.blog/changelog/2021-08-12-git-password-authentication-is-shutting-down/)